### PR TITLE
Remove default value for name property

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -4,14 +4,6 @@ set -euo pipefail
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
-get_ecr_url() {
-  local repository_name="${1}"
-  aws ecr describe-repositories \
-    --repository-names "${repository_name}" \
-    --output text \
-    --query 'repositories[0].repositoryUri'
-}
-
 ecr_exists() {
   local repository_name="${1}"
   aws ecr describe-repositories \
@@ -46,6 +38,11 @@ upsert_ecr() {
 }
 
 $(aws ecr get-login --no-include-email)
-default_repository_name="build-cache/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}"
-repository_name="${BUILDKITE_PLUGIN_CREATE_ECR_NAME:-${default_repository_name}}"
+
+if [[ -z ${BUILDKITE_PLUGIN_CREATE_ECR_NAME:-} ]]; then
+  echo "'name' property is required"
+  exit 1
+fi
+
+repository_name="${BUILDKITE_PLUGIN_CREATE_ECR_NAME:-}"
 upsert_ecr "${repository_name}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -6,6 +6,7 @@ basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
 ecr_exists() {
   local repository_name="${1}"
+
   aws ecr describe-repositories \
     --repository-names "${repository_name}" \
     --output text \
@@ -14,6 +15,7 @@ ecr_exists() {
 
 upsert_ecr() {
   local repository_name="${1}"
+
   if ! ecr_exists "${repository_name}"; then
     echo '--- Creating ECR repository'
     echo "Name: ${repository_name}"
@@ -37,12 +39,11 @@ upsert_ecr() {
   --lifecycle-policy-text "file://${lifecycle_policy_file}"
 }
 
-$(aws ecr get-login --no-include-email)
-
 if [[ -z ${BUILDKITE_PLUGIN_CREATE_ECR_NAME:-} ]]; then
   echo "'name' property is required"
   exit 1
 fi
 
 repository_name="${BUILDKITE_PLUGIN_CREATE_ECR_NAME:-}"
+
 upsert_ecr "${repository_name}"

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -44,6 +44,6 @@ if [[ -z ${BUILDKITE_PLUGIN_CREATE_ECR_NAME:-} ]]; then
   exit 1
 fi
 
-repository_name="${BUILDKITE_PLUGIN_CREATE_ECR_NAME:-}"
+repository_name="${BUILDKITE_PLUGIN_CREATE_ECR_NAME}"
 
 upsert_ecr "${repository_name}"


### PR DESCRIPTION
(Repository) name is documented as a required property, so this removes the
undocumented default value, which was copied from and awkwardly clashes with the
Docker ECR Cache plugin.

Side effects:

- Remove unnecessary ECR login

---

Alternate approach would be to provide a distinct and documented default value. The preference would probably be `default_repository_name="${BUILDKITE_PIPELINE_SLUG}"` for compatibility with existing tooling.