### PR TITLE
Add support to enable ECR image scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ steps:
 
 - `scan-on-push` (optional, string)
 
-  Value to enable ECR image scan. Accepted values: true or false.
+  Whether to [automatically scan images](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html#scanning-repository) pushed to the ECR repository for vulnerabilities.
+  
+  Omitting this option will leave the existing image scanning configuration untouched.
 
 - `repository-policy` (optional, string)
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ steps:
 
   Name of the ECR repository.
 
+- `scan-on-push` (optional, string)
+
+  Value to enable ECR image scan. Accepted values: true or false.
+
 - `repository-policy` (optional, string)
 
   Path in local repository to the repository policy file.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ steps:
 
   Name of the ECR repository.
 
-- `scan-on-push` (optional, string)
+- `scan-on-push` (optional, boolean)
 
   Whether to [automatically scan images](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html#scanning-repository) pushed to the ECR repository for vulnerabilities.
   

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -13,9 +13,7 @@ ecr_exists() {
     --query 'repositories[0].registryId'
 }
 
-upsert_ecr() {
-  printenv
-  
+upsert_ecr() { 
   local repository_name="${1}"
 
   if ! ecr_exists "${repository_name}"; then

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -37,6 +37,14 @@ upsert_ecr() {
   aws ecr put-lifecycle-policy \
   --repository-name "${repository_name}" \
   --lifecycle-policy-text "file://${lifecycle_policy_file}"
+
+  if [[ ${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH} ]]; then
+    echo '--- Setting ECR image scaning'
+    aws ecr put-image-scanning-configuration \
+      --repository-name ${repository_name} \
+      --image-scanning-configuration \
+      scanOnPush=${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH}
+  fi
 }
 
 if [[ -z ${BUILDKITE_PLUGIN_CREATE_ECR_NAME:-} ]]; then

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -39,7 +39,7 @@ upsert_ecr() {
   --lifecycle-policy-text "file://${lifecycle_policy_file}"
 
   if [[ ${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH} ]]; then
-    echo '--- Setting ECR image scaning'
+    echo '--- Setting ECR image scanning configuration'
     aws ecr put-image-scanning-configuration \
       --repository-name ${repository_name} \
       --image-scanning-configuration \

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -43,7 +43,7 @@ upsert_ecr() {
     aws ecr put-image-scanning-configuration \
       --repository-name "${repository_name}" \
       --image-scanning-configuration \
-      scanOnPush=${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH}
+      scanOnPush="${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH}"
   fi
 }
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -40,7 +40,7 @@ upsert_ecr() {
   --repository-name "${repository_name}" \
   --lifecycle-policy-text "file://${lifecycle_policy_file}"
 
-  if [[ "${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH:-}" =~ ^(true|on|1)$ ]]; then
+  if [[ "${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH:-}" =~ ^(true|on|1|false|off|0)$ ]]; then
     echo '--- Setting ECR image scanning configuration'
     aws ecr put-image-scanning-configuration \
       --repository-name "${repository_name}" \

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -40,12 +40,18 @@ upsert_ecr() {
   --repository-name "${repository_name}" \
   --lifecycle-policy-text "file://${lifecycle_policy_file}"
 
-  if [[ "${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH:-}" =~ ^(true|on|1|false|off|0)$ ]]; then
-    echo '--- Setting ECR image scanning configuration'
+  if [[ "${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH:-}" =~ ^(true|on|1)$ ]]; then
+    echo '--- Setting ECR image scanning configuration as Enabled'
     aws ecr put-image-scanning-configuration \
       --repository-name "${repository_name}" \
       --image-scanning-configuration \
-      scanOnPush="${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH}"
+      scanOnPush=true
+  elif [[ "${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH:-}" =~ ^(false|off|0)$ ]]; then
+    echo '--- Setting ECR image scanning configuration as disabled'
+    aws ecr put-image-scanning-configuration \
+      --repository-name "${repository_name}" \
+      --image-scanning-configuration \
+      scanOnPush=false
   fi
 }
 

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -41,7 +41,7 @@ upsert_ecr() {
   --lifecycle-policy-text "file://${lifecycle_policy_file}"
 
   if [[ "${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH:-}" =~ ^(true|on|1)$ ]]; then
-    echo '--- Setting ECR image scanning configuration as Enabled'
+    echo '--- Setting ECR image scanning configuration as enabled'
     aws ecr put-image-scanning-configuration \
       --repository-name "${repository_name}" \
       --image-scanning-configuration \

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -41,7 +41,7 @@ upsert_ecr() {
   if [[ ${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH} ]]; then
     echo '--- Setting ECR image scanning configuration'
     aws ecr put-image-scanning-configuration \
-      --repository-name ${repository_name} \
+      --repository-name "${repository_name}" \
       --image-scanning-configuration \
       scanOnPush=${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH}
   fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -14,6 +14,8 @@ ecr_exists() {
 }
 
 upsert_ecr() {
+  printenv
+  
   local repository_name="${1}"
 
   if ! ecr_exists "${repository_name}"; then
@@ -38,7 +40,7 @@ upsert_ecr() {
   --repository-name "${repository_name}" \
   --lifecycle-policy-text "file://${lifecycle_policy_file}"
 
-  if [[ "${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH:-$tty_default}" =~ ^(true|on|1)$ ]]; then
+  if [[ "${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH:-}" =~ ^(true|on|1)$ ]]; then
     echo '--- Setting ECR image scanning configuration'
     aws ecr put-image-scanning-configuration \
       --repository-name "${repository_name}" \

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -38,7 +38,7 @@ upsert_ecr() {
   --repository-name "${repository_name}" \
   --lifecycle-policy-text "file://${lifecycle_policy_file}"
 
-  if [[ ${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH} ]]; then
+  if [[ "${BUILDKITE_PLUGIN_CREATE_ECR_SCAN_ON_PUSH:-$tty_default}" =~ ^(true|on|1)$ ]]; then
     echo '--- Setting ECR image scanning configuration'
     aws ecr put-image-scanning-configuration \
       --repository-name "${repository_name}" \

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,7 +10,7 @@ configuration:
     name:
       type: string
     scan-on-push:
-      type: string
+      type: boolean
     repository-policy:
       type: string
   required: ['name']

--- a/plugin.yml
+++ b/plugin.yml
@@ -9,6 +9,8 @@ configuration:
       type: string
     name:
       type: string
+    scan-on-push:
+      type: string
     repository-policy:
       type: string
   required: ['name']


### PR DESCRIPTION
Adding support to enable recently launched ECR image scan.

1. Added optional parameter "scan-on-push"
2. If "scan-on-push" parameter is set, then update scanning configuration for ECR repo.