### PR TITLE
Return a non-zero exit code when plugin encounters an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ steps:
   - command: echo 'use your new ECR repo here'
     label: ecr
     plugins:
-      - seek-oss/create-ecr#v1.4.0:
+      - seek-oss/create-ecr#v2.0.0:
           name: my-repo
 ```
 
@@ -27,7 +27,7 @@ steps:
   - command: echo 'use your new ECR repo here'
     label: ecr
     plugins:
-      - seek-oss/create-ecr#v1.4.0:
+      - seek-oss/create-ecr#v2.0.0:
           lifecycle-policy: path/to/lifecycle-policy.json
           name: my-repo
           repository-policy: path/to/repository-policy.json
@@ -40,7 +40,7 @@ steps:
   - command: echo 'use your new ECR repo here'
     label: ecr
     plugins:
-      - seek-oss/create-ecr#v1.4.0:
+      - seek-oss/create-ecr#v2.0.0:
           name: my-repo
           repository-tags-file: path/to/repository-tags-file.json
 ```
@@ -52,7 +52,7 @@ steps:
   - command: echo 'use your new ECR repo here'
     label: ecr
     plugins:
-      - seek-oss/create-ecr#v1.4.0:
+      - seek-oss/create-ecr#v2.0.0:
           name: my-repo
           regions:
             - us-west-2

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -82,7 +82,7 @@ upsert_ecr() {
       --repository-name "${repository_name}" \
       --region "${region}" \
       --image-tag-mutability "${BUILDKITE_PLUGIN_CREATE_ECR_IMAGE_TAG_MUTABILITY}"
-  fi  
+  fi
 }
 
 upsert_to_regional_ecr() {
@@ -102,11 +102,13 @@ upsert_to_regional_ecr() {
   for pid in "${!tasks[@]}"; do
     if ! wait "$pid"; then
       echo "[${tasks[${pid}]}] Task failed"
-      exit
+      exit 1
     else
       echo "[${tasks[${pid}]}] Task succeeded"
     fi
   done
+
+  echo "--- All tasks completed successfully"
 }
 
 get_regions() {


### PR DESCRIPTION
Errors currently are just logged and ignored.

The `lifecycle-policy` and `repository-policy` options are particularly problematic; if you typo the filename, it'll silently fail to apply your policy change. This could be quite problematic, depending on the scenario. Hence, the proposed change.

I've cautiously proposed that this be a major release, because it may break a few builds.